### PR TITLE
Provide options for `fig.coast`

### DIFF
--- a/.github/workflows/numpydoc.yml
+++ b/.github/workflows/numpydoc.yml
@@ -3,10 +3,10 @@ name: Numpydoc Lint
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   numpydoc-lint:
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.12'  # Adjust version as needed
+          python-version: "3.12" # Adjust version as needed
 
       - name: Install dependencies
         run: |

--- a/pygmt_helper/plots.py
+++ b/pygmt_helper/plots.py
@@ -233,7 +233,7 @@ def im_plots(
         If provided, the function will generate plots for a specific realization (run) identified by this name.
     nhm_ffp : Path, optional
         Path to the NHM file, which can provide fault trace information.
-    nz_map_data: Optional[NZMapData], default=None
+    nz_map_data : Optional[NZMapData], default=None
         The NZMapData object to supply topographic data.
     cb_limits_dict : dict, optional
         A dictionary specifying the color bar limits for each intensity measure (IM). If None, limits will be automatically computed.

--- a/pygmt_helper/plotting.py
+++ b/pygmt_helper/plotting.py
@@ -5,10 +5,10 @@ import tempfile
 from pathlib import Path
 from typing import Any, NamedTuple, Optional, Self
 
-import pooch
 import geopandas
 import numpy as np
 import pandas as pd
+import pooch
 import pygmt
 import xarray as xr
 from scipy import interpolate
@@ -157,8 +157,8 @@ def gen_region_fig(
     plot_highways: bool = True,
     plot_topo: bool = True,
     plot_kwargs: dict[str, Any] = None,
-    config_options: dict[str, str | int] = None,
-    coast_options: dict[str, str | int] = None,
+    config_options: dict[str, Any] = None,
+    coast_options: dict[str, Any] = None,
     subtitle: Optional[str] = None,
 ):
     """

--- a/pygmt_helper/plotting.py
+++ b/pygmt_helper/plotting.py
@@ -120,7 +120,13 @@ def gen_region_fig(
         Configuration options to apply to the figure. See the GMT configuration
         documentation [1]_ for available options.
     coast_options : dict, optional
-        Additional options for the coastlines. See `pygmt.Figure.coast` for details.
+        Additional options for the coastlines. If not provided and `map_data` is None,
+        the following defaults are used:
+            - "resolution": "f" (full resolution)
+            - "land": "#666666" (dark gray land color)
+            - "water": "skyblue" (light blue water color)
+            - "shorelines": ["1/0.1p,black", "2/0.1p,black"] (shoreline styles)
+        See `pygmt.Figure.coast` for additional details.
     subtitle : str, optional
         Subtitle of the figure.
 

--- a/pygmt_helper/plotting.py
+++ b/pygmt_helper/plotting.py
@@ -87,6 +87,7 @@ def gen_region_fig(
     plot_topo: bool = True,
     plot_kwargs: dict[str, Any] = None,
     config_options: dict[str, str | int] = None,
+    coast_options: dict[str, str | int] = None,
     subtitle: Optional[str] = None,
 ):
     """
@@ -118,6 +119,8 @@ def gen_region_fig(
     config_options : dict, optional
         Configuration options to apply to the figure. See the GMT configuration
         documentation [1]_ for available options.
+    coast_options : dict, optional
+        Additional options for the coastlines. See `pygmt.Figure.coast` for details.
     subtitle : str, optional
         Subtitle of the figure.
 
@@ -153,11 +156,14 @@ def gen_region_fig(
 
     # Plots the default coast (sea & inland lakes/rivers)
     if map_data is None:
+        coast_options = coast_options or {
+            "resolution": "f",
+            "land": "#666666",
+            "water": "skyblue",
+            "shorelines": ["1/0.1p,black", "2/0.1p,black"],
+        }
         fig.coast(
-            shorelines=["1/0.1p,black", "2/0.1p,black"],
-            resolution="f",
-            land="#666666",
-            water="skyblue",
+            **coast_options,
         )
     # Use the custom NZ data
     else:


### PR DESCRIPTION
Allows the user to override the basic map options for 'gen_region_fig`.